### PR TITLE
Suppress warnings (unused variable)

### DIFF
--- a/src/BDD+/BtoI.cc
+++ b/src/BDD+/BtoI.cc
@@ -139,7 +139,7 @@ int BtoI::GetInt() const
   return n;
 }
 
-static const char table[] = "0123456789ABCDEF";
+//static const char table[] = "0123456789ABCDEF";
 
 int BtoI::StrNum10(char* s) const
 {

--- a/src/BDD+/SOP.cc
+++ b/src/BDD+/SOP.cc
@@ -15,7 +15,7 @@ static const char BC_SOP_BDD = 33;
 static const char BC_ISOP1 = 34;
 static const char BC_ISOP2 = 35;
 static const char BC_SOP_IMPL = 36;
-static const char BC_SOP_SUPPORT = 37;
+//static const char BC_SOP_SUPPORT = 37;
 
 //----------- Macros for operation cache -----------
 #define SOP_CACHE_CHK_RETURN(op, fx, gx) \


### PR DESCRIPTION
When compiling SAPPOROBDD with clang 13.1.6 compiler, "warning: unused variable" occurs.
This patch fixes it.
