### PR TITLE
Fix BDD+/Makefile so that RotPiDD can be compiled by old gcc

### DIFF
--- a/src/BDD+/Makefile
+++ b/src/BDD+/Makefile
@@ -121,10 +121,10 @@ PiDD_64.o: PiDD.cc $(INCL)/PiDD.h $(INCL)/ZBDD.h $(INCL)/BDD.h
 	$(CC) $(OPT64) -c PiDD.cc -o PiDD_64.o
 
 RotPiDD_32.o: RotPiDD.cc $(INCL)/RotPiDD.h $(INCL)/ZBDD.h $(INCL)/BDD.h
-	$(CC) $(OPT) -c RotPiDD.cc -o RotPiDD_32.o
+	$(CC) $(OPT) -std=c++11 -c RotPiDD.cc -o RotPiDD_32.o
 
 RotPiDD_64.o: RotPiDD.cc $(INCL)/RotPiDD.h $(INCL)/ZBDD.h $(INCL)/BDD.h
-	$(CC) $(OPT64) -c RotPiDD.cc -o RotPiDD_64.o
+	$(CC) $(OPT64) -std=c++11 -c RotPiDD.cc -o RotPiDD_64.o
 
 SeqBDD_32.o: SeqBDD.cc $(INCL)/SeqBDD.h $(INCL)/ZBDD.h $(INCL)/BDD.h
 	$(CC) $(OPT) -c SeqBDD.cc -o SeqBDD_32.o


### PR DESCRIPTION
This commit fixes BDD+/Makefile so that RotPiDD can be compiled by old gcc (for example, gcc 4.8).

Specifically, this commit adds "-std=c++11" option when compiling RotPiDD_*.o.
Since newer compilers enable "-std=c++11" by default, the option is not needed and it affects nothing if the option is added.
