### PR TITLE
Disable X11 compile if /opt/X11/include/X11/Xlib.h does not exist

### DIFF
--- a/src/BDD+/Makefile
+++ b/src/BDD+/Makefile
@@ -22,6 +22,7 @@ $(LIB64): BDD_64.o BDDX11_64.o BDDHASH_64.o ZBDD_64.o ZBDDX11_64.o \
 	  CtoI_64.o CtoIX11_64.o BDDDG_64.o ZBDDDG_64.o \
 	  PiDD_64.o RotPiDD_64.o SeqBDD_64.o GBase_64.o BDDCT_64.o
 	  rm -f $(LIB64)
+	  touch $(DIR)/src/BDDXc/graph_64.o
 	  ar cr $(LIB64) *_64.o $(OBJC64) $(OBJX64)
 	  ranlib $(LIB64)
 
@@ -30,6 +31,7 @@ $(LIB32): BDD_32.o BDDX11_32.o BDDHASH_32.o ZBDD_32.o ZBDDX11_32.o \
 	  CtoI_32.o CtoIX11_32.o BDDDG_32.o ZBDDDG_32.o \
 	  PiDD_32.o RotPiDD_32.o SeqBDD_32.o GBase_32.o BDDCT_32.o
 	  rm -f $(LIB32)
+	  touch $(DIR)/src/BDDXc/graph_32.o
 	  ar cr $(LIB32) *_32.o $(OBJC32) $(OBJX32)
 	  ranlib $(LIB32)
 

--- a/src/INSTALL
+++ b/src/INSTALL
@@ -1,7 +1,9 @@
 cd BDDc
 make 64
-cd ../BDDXc
-make 64
+if [ -e /opt/X11/include/X11/Xlib.h ]; then
+    cd ../BDDXc
+    make 64
+fi
 cd ../BDD+
 make 64
 cd ..

--- a/src/INSTALL32
+++ b/src/INSTALL32
@@ -1,7 +1,9 @@
 cd BDDc
 make 32
-cd ../BDDXc
-make 32
+if [ -e /opt/X11/include/X11/Xlib.h ]; then
+    cd ../BDDXc
+    make 32
+fi
 cd ../BDD+
 make 32
 cd ..


### PR DESCRIPTION
This commit fixes Makefile so that X11 compile is disabled if /opt/X11/include/X11/Xlib.h does not exist.

This commit suppresses X11 compile error message.
